### PR TITLE
feat(i18n): complete i18n implementation for CLI and HTML

### DIFF
--- a/scripts/git-log.html
+++ b/scripts/git-log.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>工作内容Git提交记录汇总</title>
+    <title data-i18n="workContentTitle"></title>
     <!-- echarts -->
     <script src="https://cdn.jsdelivr.net/npm/echarts/dist/echarts.min.js"></script>
 
@@ -90,6 +90,8 @@
     </style>
   </head>
   <body class="bg-gray-50 dark:bg-gray-900 transition-colors duration-300">
+    <!-- i18n Language Selector -->
+    <div id="i18n-lang" data-lang="zh" style="display:none"></div>
     <!-- Theme Toggle -->
     <div class="fixed top-4 right-4 z-50">
       <button
@@ -107,27 +109,27 @@
         <div class="text-center fade-in">
           <h1 class="text-4xl md:text-6xl font-bold mb-4">
             <i class="fab fa-git-alt mr-4"></i>
-            工作内容提交记录
+            <span data-i18n="workContentTitle"></span>
           </h1>
-          <p class="text-xl md:text-2xl text-white/90 mb-8">项目开发进度可视化看板</p>
+          <p class="text-xl md:text-2xl text-white/90 mb-8" data-i18n="projectDashboard"></p>
 
           <!-- Stats Cards -->
           <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mt-12">
             <div class="bg-white/10 glass-effect rounded-2xl p-6 fade-in stagger-1">
               <div class="text-3xl font-bold" id="total-commits">--</div>
-              <div class="text-white/80">总提交数</div>
+              <div class="text-white/80" data-i18n="totalCommits"></div>
             </div>
             <div class="bg-white/10 glass-effect rounded-2xl p-6 fade-in stagger-2">
               <div class="text-3xl font-bold" id="active-days">--</div>
-              <div class="text-white/80">活跃天数</div>
+              <div class="text-white/80" data-i18n="activeDays"></div>
             </div>
             <div class="bg-white/10 glass-effect rounded-2xl p-6 fade-in stagger-3">
               <div class="text-3xl font-bold" class="repo-name">--</div>
-              <div class="text-white/80">项目名称</div>
+              <div class="text-white/80" data-i18n="projectName"></div>
             </div>
             <div class="bg-white/10 glass-effect rounded-2xl p-6 fade-in">
               <div class="text-3xl font-bold" id="dev-month">--</div>
-              <div class="text-white/80">开发月份</div>
+              <div class="text-white/80" data-i18n="devMonth"></div>
             </div>
           </div>
         </div>
@@ -146,14 +148,14 @@
               <i class="fas fa-code text-white text-2xl"></i>
             </div>
             <div>
-              <h2 class="text-2xl font-bold text-gray-900 dark:text-white">项目: <span class="repo-name">--</span></h2>
-              <p class="text-gray-600 dark:text-gray-400">开发者: <span id="developer-name">--</span></p>
+              <h2 class="text-2xl font-bold text-gray-900 dark:text-white"><span data-i18n="project"></span>: <span class="repo-name">--</span></h2>
+              <p class="text-gray-600 dark:text-gray-400"><span data-i18n="developer"></span>: <span id="developer-name">--</span></p>
             </div>
           </div>
           <div class="text-right">
-            <div class="text-sm text-gray-500 dark:text-gray-400">统计时间范围</div>
+            <div class="text-sm text-gray-500 dark:text-gray-400"><span data-i18n="timeRange"></span></div>
             <div class="text-lg font-semibold text-gray-900 dark:text-white">
-              <span id="startDate"></span> 至 <span id="endDate"></span>
+              <span id="startDate"></span> <span data-i18n="to"></span> <span id="endDate"></span>
             </div>
           </div>
         </div>
@@ -164,27 +166,27 @@
         <div class="bg-green-50 dark:bg-green-900/20 rounded-2xl p-6 text-center fade-in">
           <div class="text-3xl font-bold text-green-600 dark:text-green-400" id="feat-count">--</div>
           <div class="text-green-800 dark:text-green-300 font-medium">feat</div>
-          <div class="text-xs text-green-600 dark:text-green-400">新功能</div>
+          <div class="text-xs text-green-600 dark:text-green-400"><span data-i18n="featDesc"></span></div>
         </div>
         <div class="bg-red-50 dark:bg-red-900/20 rounded-2xl p-6 text-center fade-in stagger-1">
           <div class="text-3xl font-bold text-red-600 dark:text-red-400" id="fix-count">--</div>
           <div class="text-red-800 dark:text-red-300 font-medium">fix</div>
-          <div class="text-xs text-red-600 dark:text-red-400">问题修复</div>
+          <div class="text-xs text-red-600 dark:text-red-400"><span data-i18n="fixDesc"></span></div>
         </div>
         <div class="bg-blue-50 dark:bg-blue-900/20 rounded-2xl p-6 text-center fade-in stagger-2">
           <div class="text-3xl font-bold text-blue-600 dark:text-blue-400" id="docs-count">--</div>
           <div class="text-blue-800 dark:text-blue-300 font-medium">docs</div>
-          <div class="text-xs text-blue-600 dark:text-blue-400">文档更新</div>
+          <div class="text-xs text-blue-600 dark:text-blue-400"><span data-i18n="docsDesc"></span></div>
         </div>
         <div class="bg-gray-50 dark:bg-gray-800 rounded-2xl p-6 text-center fade-in stagger-3">
           <div class="text-3xl font-bold text-gray-600 dark:text-gray-400" id="chore-count">--</div>
           <div class="text-gray-800 dark:text-gray-300 font-medium">chore</div>
-          <div class="text-xs text-gray-600 dark:text-gray-400">构建维护</div>
+          <div class="text-xs text-gray-600 dark:text-gray-400"><span data-i18n="choreDesc"></span></div>
         </div>
         <div class="bg-purple-50 dark:bg-purple-900/20 rounded-2xl p-6 text-center fade-in">
           <div class="text-3xl font-bold text-purple-600 dark:text-purple-400" id="refactor-count">--</div>
           <div class="text-purple-800 dark:text-purple-300 font-medium">refactor</div>
-          <div class="text-xs text-purple-600 dark:text-purple-400">重构代码</div>
+          <div class="text-xs text-purple-600 dark:text-purple-400"><span data-i18n="refactorDesc"></span></div>
         </div>
       </div>
       <!-- 雷达图展示的 提交类型分布 -->
@@ -192,7 +194,7 @@
         <div class="bg-white dark:bg-gray-800 rounded-3xl shadow-xl p-8 fade-in">
           <h3 class="text-2xl font-bold text-gray-900 dark:text-white mb-6 text-center">
             <i class="fas fa-chart-radar mr-2"></i>
-            提交类型分布
+            <span data-i18n="commitTypeDist"></span>
           </h3>
           <div id="commit-type-chart" style="width: 100%; height: 400px"></div>
         </div>
@@ -236,6 +238,123 @@
     </footer>
   </body>
   <script>
+    const i18n = {
+      zh: {
+        workContentTitle: '工作内容提交记录',
+        projectDashboard: '项目开发进度可视化看板',
+        totalCommits: '总提交数',
+        activeDays: '活跃天数',
+        projectName: '项目名称',
+        devMonth: '开发月份',
+        project: '项目',
+        developer: '开发者',
+        timeRange: '统计时间范围',
+        to: '至',
+        featDesc: '新功能',
+        fixDesc: '问题修复',
+        docsDesc: '文档更新',
+        choreDesc: '构建维护',
+        refactorDesc: '重构代码',
+        commitTypeDist: '提交类型分布',
+        commits: 'commits',
+        showMore: '显示更多提交 ({count}个)',
+        hide: '隐藏提交',
+        noData: '暂无提交类型数据',
+        monthSuffix: '月',
+        // type labels
+        feat: '功能',
+        fix: '修复',
+        docs: '文档',
+        style: '样式',
+        refactor: '重构',
+        perf: '性能',
+        test: '测试',
+        build: '构建',
+        ci: 'CI',
+        chore: '维护',
+        revert: '回滚',
+        other: '其他',
+        // summaries
+        featSummary: '新增了系统功能或组件',
+        fixSummary: '修复了系统问题或错误',
+        docsSummary: '更新了文档或注释',
+        styleSummary: '调整了代码格式或样式',
+        refactorSummary: '优化了代码结构或性能',
+        perfSummary: '提升了系统性能或响应速度',
+        testSummary: '完善了测试用例或测试覆盖',
+        buildSummary: '更新了构建系统或依赖配置',
+        ciSummary: '调整了CI/CD流程或配置',
+        choreSummary: '完成了维护任务或杂项工作',
+        revertSummary: '回滚了之前的代码更改',
+        otherSummary: '完成了代码更改',
+      },
+      en: {
+        workContentTitle: 'Work Content Commits',
+        projectDashboard: 'Project Development Dashboard',
+        totalCommits: 'Total Commits',
+        activeDays: 'Active Days',
+        projectName: 'Project Name',
+        devMonth: 'Dev Month',
+        project: 'Project',
+        developer: 'Developer',
+        timeRange: 'Time Range',
+        to: 'to',
+        featDesc: 'Features',
+        fixDesc: 'Fixes',
+        docsDesc: 'Documentation',
+        choreDesc: 'Maintenance',
+        refactorDesc: 'Refactoring',
+        commitTypeDist: 'Commit Type Distribution',
+        commits: 'commits',
+        showMore: 'Show more ({count})',
+        hide: 'Hide',
+        noData: 'No commit type data',
+        monthSuffix: '',
+        // type labels
+        feat: 'feat',
+        fix: 'fix',
+        docs: 'docs',
+        style: 'style',
+        refactor: 'refactor',
+        perf: 'perf',
+        test: 'test',
+        build: 'build',
+        ci: 'CI',
+        chore: 'chore',
+        revert: 'revert',
+        other: 'other',
+        // summaries
+        featSummary: 'Added new functionality',
+        fixSummary: 'Fixed system issues',
+        docsSummary: 'Updated documentation',
+        styleSummary: 'Adjusted code style',
+        refactorSummary: 'Optimized code structure',
+        perfSummary: 'Improved performance',
+        testSummary: 'Enhanced test coverage',
+        buildSummary: 'Updated build configuration',
+        ciSummary: 'Adjusted CI/CD pipeline',
+        choreSummary: 'Completed maintenance tasks',
+        revertSummary: 'Reverted previous changes',
+        otherSummary: 'Made code changes',
+      },
+    };
+
+    function t(key) {
+      const lang = document.getElementById('i18n-lang')?.dataset?.lang || 'zh';
+      const value = i18n[lang]?.[key];
+      if (value !== undefined) return value;
+      const fallbackValue = i18n['zh']?.[key];
+      if (fallbackValue !== undefined) return fallbackValue;
+      return key;
+    }
+
+    function applyI18n() {
+      document.querySelectorAll('[data-i18n]').forEach(el => {
+        const key = el.dataset.i18n;
+        if (key) el.textContent = t(key);
+      });
+    }
+
     function getAuthorNames(data) {
       const authorSet = new Set()
       data.repositories.forEach((repo) => {
@@ -261,7 +380,7 @@
         document.documentElement.classList.add('dark')
       }
 
-      const STATIC_DATA = ``
+      const STATIC_DATA = null;
       if (!!STATIC_DATA) {
         return renderCommitData(STATIC_DATA)
       }
@@ -280,7 +399,8 @@
 
     function renderCommitData(data) {
       const names = getAuthorNames(data)
-      document.title = `工作内容Git提交记录汇总 - ${names.join(', ')}`
+      applyI18n()
+      document.title = `${t('workContentTitle')} - ${names.join(', ')}`
       document.getElementById('developer-name').textContent = names.join(', ')
       const { repositories, timeRange, author } = data
       document.getElementById('startDate').textContent = timeRange.since
@@ -322,17 +442,17 @@
 
       // 准备雷达图数据
       const commitTypeLabels = {
-        feat: '新功能',
-        fix: '问题修复',
-        docs: '文档更新',
-        style: '样式调整',
-        refactor: '重构代码',
-        perf: '性能优化',
-        test: '测试相关',
-        build: '构建系统',
-        ci: 'CI配置',
-        chore: '构建维护',
-        revert: '回滚更改',
+        feat: t('feat'),
+        fix: t('fix'),
+        docs: t('docs'),
+        style: t('style'),
+        refactor: t('refactor'),
+        perf: t('perf'),
+        test: t('test'),
+        build: t('build'),
+        ci: t('ci'),
+        chore: t('chore'),
+        revert: t('revert'),
       }
 
       const radarData = []
@@ -393,12 +513,12 @@
         },
         series: [
           {
-            name: '提交类型分布',
+            name: t('commitTypeDist'),
             type: 'radar',
             data: [
               {
                 value: chartData,
-                name: '提交数量',
+                name: t('totalCommits'),
                 areaStyle: {
                   color: isDark ? 'rgba(59, 130, 246, 0.3)' : 'rgba(59, 130, 246, 0.2)',
                 },
@@ -429,7 +549,7 @@
             left: 'center',
             top: 'middle',
             style: {
-              text: '暂无提交类型数据',
+              text: t('noData'),
               fontSize: 16,
               fill: isDark ? '#9ca3af' : '#6b7280',
             },
@@ -484,7 +604,7 @@
       // 更新显示
       const devMonthEl = document.getElementById('dev-month')
       if (devMonthEl) {
-        devMonthEl.textContent = `${month}月`
+        devMonthEl.textContent = `${month}${t('monthSuffix')}`
       }
     }
 
@@ -549,7 +669,7 @@
             )}-900/30 text-${getRandomColor(date)}-800 dark:text-${getRandomColor(
               date,
             )}-300 px-3 py-1 rounded-full text-sm font-medium"
-            >${commits.length} commits</span>
+            >${commits.length} ${t("commits")}</span>
         `
 
         // 提交列表容器
@@ -575,7 +695,7 @@
               data-date="${date}"
             >
               <i class="fas fa-chevron-down mr-1"></i>
-              显示更多提交 (${commits.length - 3}个)
+              ${t('showMore').replace('{count}', commits.length - 3)}
             </button>
           `
 
@@ -612,11 +732,11 @@
             if (hiddenCommits.classList.contains('hidden')) {
               icon.classList.remove('fa-chevron-up')
               icon.classList.add('fa-chevron-down')
-              this.innerHTML = this.innerHTML.replace('隐藏提交', `显示更多提交 (${hiddenCommits.children.length}个)`)
+              this.innerHTML = this.innerHTML.replace(t('hide'), t('showMore').replace('{count}', hiddenCommits.children.length))
             } else {
               icon.classList.remove('fa-chevron-down')
               icon.classList.add('fa-chevron-up')
-              this.innerHTML = this.innerHTML.replace(/显示更多提交 \(\d+个\)/, '隐藏提交')
+              this.innerHTML = this.innerHTML.replace(t('showMore').replace('{count}', hiddenCommits.children.length), t('hide'))
             }
           }
         })
@@ -688,67 +808,67 @@
           icon: 'fas fa-plus',
           bgColor: 'green',
           textColor: 'green',
-          label: '功能',
+          label: t('feat'),
         },
         fix: {
           icon: 'fas fa-bug',
           bgColor: 'red',
           textColor: 'red',
-          label: '修复',
+          label: t('fix'),
         },
         docs: {
           icon: 'fas fa-file-alt',
           bgColor: 'blue',
           textColor: 'blue',
-          label: '文档',
+          label: t('docs'),
         },
         style: {
           icon: 'fas fa-paint-brush',
           bgColor: 'pink',
           textColor: 'pink',
-          label: '样式',
+          label: t('style'),
         },
         refactor: {
           icon: 'fas fa-sync-alt',
           bgColor: 'purple',
           textColor: 'purple',
-          label: '重构',
+          label: t('refactor'),
         },
         perf: {
           icon: 'fas fa-tachometer-alt',
           bgColor: 'orange',
           textColor: 'orange',
-          label: '性能',
+          label: t('perf'),
         },
         test: {
           icon: 'fas fa-vial',
           bgColor: 'yellow',
           textColor: 'yellow',
-          label: '测试',
+          label: t('test'),
         },
         build: {
           icon: 'fas fa-hammer',
           bgColor: 'indigo',
           textColor: 'indigo',
-          label: '构建',
+          label: t('build'),
         },
         ci: {
           icon: 'fas fa-server',
           bgColor: 'teal',
           textColor: 'teal',
-          label: 'CI',
+          label: t('ci'),
         },
         chore: {
           icon: 'fas fa-cog',
           bgColor: 'gray',
           textColor: 'gray',
-          label: '维护',
+          label: t('chore'),
         },
         revert: {
           icon: 'fas fa-undo',
           bgColor: 'red',
           textColor: 'red',
-          label: '回滚',
+          label: t('revert'),
         },
       }
 
@@ -756,7 +876,7 @@
         icon: 'fas fa-code',
         bgColor: 'gray',
         textColor: 'gray',
-        label: '其他',
+        label: t('other'),
       }
 
       return {
@@ -778,29 +898,29 @@
       // 根据提交类型生成简短总结
       switch (type) {
         case 'feat':
-          return description.includes('添加') ? '新增了系统功能或组件' : '增强了系统功能或用户体验'
+          return t('featSummary')
         case 'fix':
-          return '修复了系统问题或错误'
+          return t('fixSummary')
         case 'docs':
-          return '更新了文档或注释'
+          return t('docsSummary')
         case 'style':
-          return '调整了代码格式或样式'
+          return t('styleSummary')
         case 'refactor':
-          return '优化了代码结构或性能'
+          return t('refactorSummary')
         case 'perf':
-          return '提升了系统性能或响应速度'
+          return t('perfSummary')
         case 'test':
-          return '完善了测试用例或测试覆盖'
+          return t('testSummary')
         case 'build':
-          return '更新了构建系统或依赖配置'
+          return t('buildSummary')
         case 'ci':
-          return '调整了CI/CD流程或配置'
+          return t('ciSummary')
         case 'chore':
-          return '完成了维护任务或杂项工作'
+          return t('choreSummary')
         case 'revert':
-          return '回滚了之前的代码更改'
+          return t('revertSummary')
         default:
-          return '完成了代码更改'
+          return t('otherSummary')
       }
     }
 
@@ -808,7 +928,14 @@
       // 将 2025-04-29 格式转换为 2025年4月29日
       const parts = dateStr.split('-')
       if (parts.length === 3) {
-        return `${parts[0]}年${parseInt(parts[1])}月${parseInt(parts[2])}日`
+        const year = parts[0]
+        const month = parseInt(parts[1])
+        const day = parseInt(parts[2])
+        if (t('monthSuffix')) {
+          return `${year}年${month}月${day}日`
+        } else {
+          return `${year}-${month.toString().padStart(2, '0')}-${day.toString().padStart(2, '0')}`
+        }
       }
       return dateStr
     }

--- a/scripts/weekly-git-summary.ps1
+++ b/scripts/weekly-git-summary.ps1
@@ -63,16 +63,23 @@ function New-HtmlOutput {
             $scriptArgs += "--author", "`"$author`""
         }
     }
+    $scriptArgs += "--lang", $script:LANG
     $scriptArgs += "--json"
     
     $jsonData = & $MyInvocation.ScriptName @scriptArgs
     
+    $jsonObject = $jsonData | ConvertFrom-Json
+    $jsonObject | Add-Member -Name "lang" -Value $script:LANG -MemberType NoteProperty -Force
+    $jsonDataWithLang = $jsonObject | ConvertTo-Json -Depth 10
+    
     # 读取模板文件内容
     $templateContent = Get-Content $templateFile -Raw
-    
-    # 替换模板中的 STATIC_DATA
-    $modifiedContent = $templateContent -replace 'const STATIC_DATA = ``;', "const STATIC_DATA = $jsonData;"
-    
+
+    # 替换模板中的 STATIC_DATA 和 lang 属性
+    $modifiedContent = $templateContent `
+        -replace 'const STATIC_DATA = null;', "const STATIC_DATA = $jsonDataWithLang;" `
+        -replace 'data-lang="zh"', "data-lang=`"$script:LANG`""
+
     $modifiedContent
     # 写入输出文件
     # $modifiedContent | Out-File -FilePath $outputFile -Encoding UTF8

--- a/scripts/weekly-git-summary.ps1
+++ b/scripts/weekly-git-summary.ps1
@@ -87,6 +87,76 @@ $GREEN = [System.ConsoleColor]::Green
 $YELLOW = [System.ConsoleColor]::Yellow
 $RED = [System.ConsoleColor]::Red
 
+$script:LANG = "zh"
+
+for ($i = 0; $i -lt $args.Count; $i++) {
+    if ($args[$i] -eq "--lang" -and ($i + 1) -lt $args.Count) {
+        if ($args[$i + 1] -eq "en") {
+            $script:LANG = "en"
+        }
+        break
+    }
+}
+
+function Get-Message {
+    param(
+        [string]$key
+    )
+    
+    if ($script:LANG -eq "en") {
+        switch ($key) {
+            "usage" { return "Usage:" }
+            "options" { return "Options:" }
+            "examples" { return "Examples:" }
+            "help" { return "Show this help message" }
+            "dir" { return "Specify search directory (default: current directory)" }
+            "since" { return "Specify start date (format: YYYY-MM-DD, default: this Monday)" }
+            "until" { return "Specify end date (format: YYYY-MM-DD, default: today)" }
+            "author" { return "Show commits by specified author only" }
+            "json" { return "Output result in JSON format" }
+            "markdown" { return "Output result in Markdown format" }
+            "html" { return "Generate HTML visualization file" }
+            "lang" { return "Set output language (zh|en, default: zh)" }
+            "author_text" { return "author" }
+            "hash" { return "hash" }
+            "project" { return "Project" }
+            "time_range_label" { return "Time Range" }
+            "search_dir_label" { return "Search Directory" }
+            "author_filter" { return "Author Filter" }
+            "git_commit_summary" { return "Git Commit Summary" }
+            "error_unknown_param" { return "Error: Unknown parameter" }
+            "error_dir_not_exist" { return "Error: Directory does not exist" }
+            default { return $key }
+        }
+    }
+    else {
+        switch ($key) {
+            "usage" { return "使用方法:" }
+            "options" { return "选项:" }
+            "examples" { return "示例:" }
+            "help" { return "显示此帮助信息" }
+            "dir" { return "指定搜索目录 (默认: 当前目录)" }
+            "since" { return "指定开始日期 (格式: YYYY-MM-DD, 默认: 本周一)" }
+            "until" { return "指定结束日期 (格式: YYYY-MM-DD, 默认: 今天)" }
+            "author" { return "只显示指定作者的提交" }
+            "json" { return "以JSON格式输出结果" }
+            "markdown" { return "以Markdown格式输出结果" }
+            "html" { return "生成HTML可视化文件" }
+            "lang" { return "设置输出语言 (zh|en, 默认: zh)" }
+            "author_text" { return "作者" }
+            "hash" { return "hash" }
+            "project" { return "项目" }
+            "time_range_label" { return "统计时间范围" }
+            "search_dir_label" { return "搜索目录" }
+            "author_filter" { return "作者过滤" }
+            "git_commit_summary" { return "工作内容Git提交记录汇总" }
+            "error_unknown_param" { return "错误: 未知参数" }
+            "error_dir_not_exist" { return "错误: 目录不存在" }
+            default { return $key }
+        }
+    }
+}
+
 # 默认值
 $SEARCH_DIR = "."
 # 获取本周一的日期
@@ -103,23 +173,32 @@ $HTML_OUTPUT = $false
 
 # 显示帮助信息
 function Show-Help {
-    Write-Host "使用方法:" -ForegroundColor $BLUE
-    Write-Host "  .\weekly-git-summary.ps1 [选项]"
+    Write-Host "$(Get-Message "usage")" -ForegroundColor $BLUE
+    Write-Host "  .\weekly-git-summary.ps1 [options]"
     Write-Host ""
-    Write-Host "选项:" -ForegroundColor $GREEN
-    Write-Host "  -h, --help         显示此帮助信息"
-    Write-Host "  -d, --dir DIR      指定搜索目录 (默认: 当前目录)"
-    Write-Host "  -s, --since DATE   指定开始日期 (格式: YYYY-MM-DD, 默认: 本周一)"
-    Write-Host "  -u, --until DATE   指定结束日期 (格式: YYYY-MM-DD, 默认: 今天)"
-    Write-Host "  -a, --author NAME  只显示指定作者的提交"
-    Write-Host "  -j, --json         以JSON格式输出结果"
-    Write-Host "  -m, --md           以Markdown格式输出结果"
-    Write-Host "  --html             生成HTML可视化文件"
+    Write-Host "$(Get-Message "options")" -ForegroundColor $GREEN
+    Write-Host "  -h, --help         $(Get-Message "help")"
+    Write-Host "  -d, --dir DIR      $(Get-Message "dir")"
+    Write-Host "  -s, --since DATE   $(Get-Message "since")"
+    Write-Host "  -u, --until DATE   $(Get-Message "until")"
+    Write-Host "  -a, --author NAME  $(Get-Message "author")"
+    Write-Host "  -j, --json         $(Get-Message "json")"
+    Write-Host "  -m, --md           $(Get-Message "markdown")"
+    Write-Host "  --html             $(Get-Message "html")"
+    Write-Host "  --lang LANG        $(Get-Message "lang")"
     Write-Host ""
-    Write-Host "示例:" -ForegroundColor $YELLOW
-    Write-Host "  .\weekly-git-summary.ps1 -dir C:\projects -since 2023-01-01 -until 2023-01-31"
-    Write-Host "  .\weekly-git-summary.ps1 -author '张三' -since 2023-01-01"
-    Write-Host "  .\weekly-git-summary.ps1 -json -since 2023-01-01"
+    Write-Host "$(Get-Message "examples")" -ForegroundColor $YELLOW
+    if ($script:LANG -eq "en") {
+        Write-Host "  .\weekly-git-summary.ps1 -dir C:\projects -since 2023-01-01 -until 2023-01-31"
+        Write-Host "  .\weekly-git-summary.ps1 -author 'John Doe' -since 2023-01-01"
+        Write-Host "  .\weekly-git-summary.ps1 -json -since 2023-01-01"
+        Write-Host "  .\weekly-git-summary.ps1 -json -lang en"
+    }
+    else {
+        Write-Host "  .\weekly-git-summary.ps1 -dir C:\projects -since 2023-01-01 -until 2023-01-31"
+        Write-Host "  .\weekly-git-summary.ps1 -author '张三' -since 2023-01-01"
+        Write-Host "  .\weekly-git-summary.ps1 -json -since 2023-01-01"
+    }
     exit
 }
 
@@ -173,8 +252,18 @@ while ($i -lt $args.Count) {
             $i += 1
             continue
         }
+        "--lang" {
+            if ($args[$i + 1] -eq "en") {
+                $script:LANG = "en"
+            }
+            else {
+                $script:LANG = "zh"
+            }
+            $i += 2
+            continue
+        }
         default {
-            Write-Host "错误: 未知参数 $($args[$i])" -ForegroundColor $RED
+            Write-Host "$(Get-Message "error_unknown_param"): $($args[$i])" -ForegroundColor $RED
             Show-Help
             exit 1
         }
@@ -183,7 +272,7 @@ while ($i -lt $args.Count) {
 
 # 检查搜索目录是否存在
 if (-not (Test-Path $SEARCH_DIR -PathType Container)) {
-    Write-Host "错误: 目录 '$SEARCH_DIR' 不存在" -ForegroundColor $RED
+    Write-Host "$(Get-Message "error_dir_not_exist"): '$SEARCH_DIR'" -ForegroundColor $RED
     exit 1
 }
 
@@ -219,14 +308,19 @@ elseif ($HTML_OUTPUT) {
     # 这里不需要输出任何内容，HTML 输出会在 New-HtmlOutput 函数中处理
 }
 else {
-    Write-Host "===== 工作内容Git提交记录汇总 =====" -ForegroundColor $BLUE
-    Write-Host "统计时间范围: " -NoNewline -ForegroundColor $GREEN
-    Write-Host "$MONDAY 到 $TODAY"
-    Write-Host "搜索目录: " -NoNewline -ForegroundColor $GREEN
+    Write-Host "===== $(Get-Message "git_commit_summary") =====" -ForegroundColor $BLUE
+    Write-Host "$(Get-Message "time_range_label"): " -NoNewline -ForegroundColor $GREEN
+    if ($script:LANG -eq "en") {
+        Write-Host "$MONDAY to $TODAY"
+    }
+    else {
+        Write-Host "$MONDAY 到 $TODAY"
+    }
+    Write-Host "$(Get-Message "search_dir_label"): " -NoNewline -ForegroundColor $GREEN
     Write-Host "$SEARCH_DIR"
     if ($AUTHORS.Count -gt 0) {
         $authorsStr = $AUTHORS -join ", "
-        Write-Host "作者过滤: " -NoNewline -ForegroundColor $GREEN
+        Write-Host "$(Get-Message "author_filter"): " -NoNewline -ForegroundColor $GREEN
         Write-Host "$authorsStr"
     }
     Write-Host ""
@@ -325,7 +419,7 @@ foreach ($gitDir in $gitDirs) {
                     "### $date"
                     $CURRENT_DATE = $date
                 }
-                "- $message (作者: $author, hash: $hash)"
+                "- $message ($(Get-Message "author_text"): $author, $(Get-Message "hash"): $hash)"
             }
             ""
         }
@@ -333,7 +427,7 @@ foreach ($gitDir in $gitDirs) {
             # do nothing, HTML output will be generated later
         }
         else {
-            Write-Host "项目: $REPO_NAME" -ForegroundColor $YELLOW
+            Write-Host "$(Get-Message "project"): $REPO_NAME" -ForegroundColor $YELLOW
             Write-Host ""
             
             # 按日期分组显示提交
@@ -349,7 +443,7 @@ foreach ($gitDir in $gitDirs) {
                     Write-Host "$date" -ForegroundColor $GREEN
                     $CURRENT_DATE = $date
                 }
-                Write-Host "  • $message (作者: $author, hash: $hash)"
+                Write-Host "  • $message ($(Get-Message "author_text"): $author, $(Get-Message "hash"): $hash)"
             }
             Write-Host ""
             Write-Host "-----------------------------------------"

--- a/scripts/weekly-git-summary.sh
+++ b/scripts/weekly-git-summary.sh
@@ -45,7 +45,12 @@ SEARCH_DIR="."
 # 然后计算到本周一的偏移天数
 CURRENT_WEEKDAY=$(date +%w)
 DAYS_TO_MONDAY=$(( (($CURRENT_WEEKDAY + 6) % 7) ))
-MONDAY=$(date -v-${DAYS_TO_MONDAY}d +%Y-%m-%d)
+# GNU date (Linux) vs BSD date (macOS)
+if date --version >/dev/null 2>&1; then
+    MONDAY=$(date -d "-${DAYS_TO_MONDAY} days" +%Y-%m-%d)
+else
+    MONDAY=$(date -v-${DAYS_TO_MONDAY}d +%Y-%m-%d)
+fi
 TODAY=$(date +%Y-%m-%d)
 AUTHORS=()
 JSON_OUTPUT=false

--- a/scripts/weekly-git-summary.sh
+++ b/scripts/weekly-git-summary.sh
@@ -89,6 +89,8 @@ translate() {
                 "summary_completed") echo "Summary Completed" ;;
                 "to") echo "to" ;;
                 "author_text") echo "author" ;;
+                "project") echo "Project" ;;
+                "hash") echo "hash" ;;
                 *) echo "$key" ;;
             esac
             ;;
@@ -117,6 +119,8 @@ translate() {
                 "summary_completed") echo "工作内容汇总完成" ;;
                 "to") echo "到" ;;
                 "author_text") echo "作者" ;;
+                "project") echo "项目" ;;
+                "hash") echo "hash" ;;
                 *) echo "$key" ;;
             esac
             ;;
@@ -451,11 +455,11 @@ while read gitdir; do
                     echo "### $date"
                     CURRENT_DATE="$date"
                 fi
-                echo "- $message (作者: $author, hash: $hash)"
+                  echo "- $message ($(translate "author_text" "$LANG_OUTPUT"): $author, $(translate "hash" "$LANG_OUTPUT"): $hash)"
             done
             echo ""
         elif [ "$HTML_OUTPUT" = false ]; then
-            echo -e "${YELLOW}项目: $REPO_NAME${NC}"
+            echo -e "${YELLOW}$(translate "project" "$LANG_OUTPUT"): $REPO_NAME${NC}"
             echo ""
             
             # 按日期分组显示提交
@@ -465,7 +469,7 @@ while read gitdir; do
                     echo -e "${GREEN}$date${NC}"
                     CURRENT_DATE="$date"
                 fi
-                echo "  • $message (作者: $author, hash: $hash)"
+                echo "  • $message ($(translate "author_text" "$LANG_OUTPUT"): $author, $(translate "hash" "$LANG_OUTPUT"): $hash)"
             done
             
             echo ""

--- a/scripts/weekly-git-summary.sh
+++ b/scripts/weekly-git-summary.sh
@@ -157,14 +157,17 @@ generate_html_output() {
     done
     
     # 转义`字符
-    local json_data=$(eval "$0 $args --json" | sed 's/`/\\`/g')
+    local json_data=$(eval "$0 $args --lang $LANG_OUTPUT --json" | sed 's/`/\\`/g')
+    
+    local json_with_lang=$(echo "$json_data" | sed "0,/{/{s/{/{\\n  \"lang\": \"$LANG_OUTPUT\",/}")
     
     # 读取模板文件内容
     local template_content=$(cat "$template_file")
-    
-    # 替换模板中的 STATIC_DATA
-    local modified_content="${template_content//const STATIC_DATA = \`\`;/const STATIC_DATA = $json_data;}"
-    
+
+    # 替换模板中的 STATIC_DATA 和 lang 属性
+    local modified_content="${template_content//const STATIC_DATA = null;/const STATIC_DATA = $json_with_lang;}"
+    modified_content="${modified_content//data-lang=\"zh\"/data-lang=\"$LANG_OUTPUT\"}"
+
     echo "$modified_content"
     # 写入输出文件
     # echo "$modified_content" > "$output_file"
@@ -277,7 +280,7 @@ while [[ $# -gt 0 ]]; do
             fi
             shift 2
             ;;
-        --message-pattern|--conventional|--time-range)
+        --html|--message-pattern|--conventional|--time-range)
             # 新功能参数，委托给 Node.js 版本处理
             
             # 检查 Node.js 版本是否存在

--- a/scripts/weekly-git-summary.ts
+++ b/scripts/weekly-git-summary.ts
@@ -220,13 +220,14 @@ function generateHtmlOutput(options: Options): void {
 
   // 检查模板文件是否存在
   if (!existsSync(templateFile)) {
-    console.error(
-      `${colors.red}错误: 找不到 HTML 模板文件 ${templateFile}${colors.reset}`,
-    )
+    const errorMsg = options.lang === 'en' 
+      ? `Error: HTML template file not found ${templateFile}`
+      : `错误: 找不到 HTML 模板文件 ${templateFile}`
+    console.error(`${colors.red}${errorMsg}${colors.reset}`)
     process.exit(1)
   }
 
-  // 直接生成 JSON 数据而不是递归调用
+  // 生成 JSON 数据
   const tempOptions: Options = {
     ...options,
     jsonOutput: true,
@@ -234,16 +235,25 @@ function generateHtmlOutput(options: Options): void {
   }
 
   const jsonOutput = generateJsonOutput(tempOptions)
-  const jsonData = JSON.stringify(jsonOutput, null, 2)
+  const dataWithLang = {
+    ...jsonOutput,
+    lang: options.lang,
+  }
+  const jsonData = JSON.stringify(dataWithLang, null, 2)
 
   // 读取模板文件内容
   const templateContent = readFileSync(templateFile, 'utf8')
 
-  // 替换模板中的 STATIC_DATA
-  const modifiedContent = templateContent.replace(
-    'const STATIC_DATA = ``',
-    `const STATIC_DATA = ${jsonData};`,
-  )
+  // 替换模板中的 STATIC_DATA 和 lang 属性
+  const modifiedContent = templateContent
+    .replace(
+      'const STATIC_DATA = null;',
+      `const STATIC_DATA = ${jsonData};`,
+    )
+    .replace(
+      'data-lang="zh"',
+      `data-lang="${options.lang}"`,
+    )
 
   console.log(modifiedContent)
 }

--- a/scripts/weekly-git-summary.ts
+++ b/scripts/weekly-git-summary.ts
@@ -59,6 +59,9 @@ const i18n = {
     revert: '回滚更改',
     other: '其他类型',
     breaking: '破坏性',
+    project: '项目',
+    hash: 'hash',
+    authorLabel: '作者',
   },
   en: {
     usage: 'Usage:',
@@ -100,6 +103,9 @@ const i18n = {
     revert: 'Reverts',
     other: 'Others',
     breaking: 'BREAKING',
+    project: 'Project',
+    hash: 'hash',
+    authorLabel: 'author',
   },
 } as const
 
@@ -954,27 +960,28 @@ export function main(): void {
         }
 
         // 显示传统提交信息
-        const authorText = options.lang === 'en' ? 'author' : '作者'
+        const authorText = t('authorLabel', options.lang)
+        const hashText = t('hash', options.lang)
         if (options.conventional) {
           const conventionalInfo = parseConventionalCommit(message)
           if (conventionalInfo) {
             const typeDisplay = getCommitTypeDisplayName(conventionalInfo.type, options.lang)
             const breakingTag = conventionalInfo.breaking ? ` **[${t('breaking', options.lang)}]**` : ''
-            console.log(`- **[${typeDisplay}]** ${conventionalInfo.description}${breakingTag} (${authorText}: ${author}, hash: ${hash})`)
+            console.log(`- **[${typeDisplay}]** ${conventionalInfo.description}${breakingTag} (${authorText}: ${author}, ${hashText}: ${hash})`)
           }
           else {
             const otherText = t('other', options.lang)
-            console.log(`- **[${otherText}]** ${message} (${authorText}: ${author}, hash: ${hash})`)
+            console.log(`- **[${otherText}]** ${message} (${authorText}: ${author}, ${hashText}: ${hash})`)
           }
         }
         else {
-          console.log(`- ${message} (${authorText}: ${author}, hash: ${hash})`)
+          console.log(`- ${message} (${authorText}: ${author}, ${hashText}: ${hash})`)
         }
       }
       console.log('')
     }
     else {
-      console.log(`${colors.yellow}项目: ${repoName}${colors.reset}`)
+      console.log(`${colors.yellow}${t('project', options.lang)}: ${repoName}${colors.reset}`)
       console.log('')
 
       // 按日期分组显示提交
@@ -992,21 +999,22 @@ export function main(): void {
         }
 
         // 显示传统提交信息
-        const authorText = options.lang === 'en' ? 'author' : '作者'
+        const authorText = t('authorLabel', options.lang)
+        const hashText = t('hash', options.lang)
         if (options.conventional) {
           const conventionalInfo = parseConventionalCommit(message)
           if (conventionalInfo) {
             const typeDisplay = getCommitTypeDisplayName(conventionalInfo.type, options.lang)
             const breakingTag = conventionalInfo.breaking ? ` ${colors.red}[${t('breaking', options.lang)}]${colors.reset}` : ''
-            console.log(`  • ${colors.blue}[${typeDisplay}]${colors.reset} ${conventionalInfo.description}${breakingTag} (${authorText}: ${author}, hash: ${hash})`)
+            console.log(`  • ${colors.blue}[${typeDisplay}]${colors.reset} ${conventionalInfo.description}${breakingTag} (${authorText}: ${author}, ${hashText}: ${hash})`)
           }
           else {
             const otherText = t('other', options.lang)
-            console.log(`  • ${colors.blue}[${otherText}]${colors.reset} ${message} (${authorText}: ${author}, hash: ${hash})`)
+            console.log(`  • ${colors.blue}[${otherText}]${colors.reset} ${message} (${authorText}: ${author}, ${hashText}: ${hash})`)
           }
         }
         else {
-          console.log(`  • ${message} (${authorText}: ${author}, hash: ${hash})`)
+          console.log(`  • ${message} (${authorText}: ${author}, ${hashText}: ${hash})`)
         }
       }
       console.log('')

--- a/tests/i18n.test.ts
+++ b/tests/i18n.test.ts
@@ -1,0 +1,275 @@
+import { execSync } from 'node:child_process'
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test'
+
+const testDir = join(process.cwd(), 'test-repo-i18n')
+const buildDir = join(process.cwd(), 'build')
+
+describe('i18n Internationalization Tests', () => {
+  beforeAll(() => {
+    // 确保构建目录存在
+    if (!existsSync(buildDir)) {
+      execSync('bun run build.ts', { cwd: process.cwd() })
+    }
+
+    // 创建测试 Git 仓库
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true })
+    }
+    mkdirSync(testDir, { recursive: true })
+
+    // 初始化 Git 仓库
+    execSync('git init --initial-branch=main', { cwd: testDir })
+    execSync('git config user.name "Test User"', { cwd: testDir })
+    execSync('git config user.email "test@example.com"', { cwd: testDir })
+
+    // 创建测试文件并提交
+    writeFileSync(join(testDir, 'test.txt'), 'test content')
+    execSync('git add .', { cwd: testDir })
+    execSync('git commit -m "Initial commit"', { cwd: testDir })
+  })
+
+  afterAll(() => {
+    // 清理测试目录
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true })
+    }
+  })
+
+  describe('TypeScript Implementation', () => {
+    it('should show Chinese help by default', () => {
+      const result = execSync('node build/cli.js --help', {
+        encoding: 'utf8',
+        cwd: process.cwd(),
+      })
+
+      expect(result).toContain('使用方法')
+      expect(result).toContain('选项')
+      expect(result).toContain('显示此帮助信息')
+    })
+
+    it('should show English help with --lang en', () => {
+      const result = execSync('node build/cli.js --help --lang en', {
+        encoding: 'utf8',
+        cwd: process.cwd(),
+      })
+
+      expect(result).toContain('Usage:')
+      expect(result).toContain('Options:')
+      expect(result).toContain('Show this help message')
+    })
+
+    it('should show Chinese output by default', () => {
+      const result = execSync(`node build/cli.js --dir ${testDir} --json`, {
+        encoding: 'utf8',
+        cwd: process.cwd(),
+      })
+
+      const jsonResult = JSON.parse(result)
+      expect(jsonResult).toHaveProperty('repositories')
+    })
+
+    it('should respect --lang zh parameter', () => {
+      const result = execSync(`node build/cli.js --dir ${testDir} --lang zh --json`, {
+        encoding: 'utf8',
+        cwd: process.cwd(),
+      })
+
+      const jsonResult = JSON.parse(result)
+      expect(jsonResult).toHaveProperty('repositories')
+    })
+
+    it('should respect --lang en parameter', () => {
+      const result = execSync(`node build/cli.js --dir ${testDir} --lang en --json`, {
+        encoding: 'utf8',
+        cwd: process.cwd(),
+      })
+
+      const jsonResult = JSON.parse(result)
+      expect(jsonResult).toHaveProperty('repositories')
+    })
+
+    it('should use translated labels in text output (Chinese)', () => {
+      const result = execSync(`node build/cli.js --dir ${testDir} --lang zh`, {
+        encoding: 'utf8',
+        cwd: process.cwd(),
+      })
+
+      expect(result).toContain('项目:')
+      expect(result).toContain('作者:')
+    })
+
+    it('should use translated labels in text output (English)', () => {
+      const result = execSync(`node build/cli.js --dir ${testDir} --lang en`, {
+        encoding: 'utf8',
+        cwd: process.cwd(),
+      })
+
+      expect(result).toContain('Project:')
+      expect(result).toContain('author:')
+    })
+
+    it('should use translated labels in markdown output (Chinese)', () => {
+      const result = execSync(`node build/cli.js --dir ${testDir} --lang zh --md`, {
+        encoding: 'utf8',
+        cwd: process.cwd(),
+      })
+
+      expect(result).toContain('工作内容Git提交记录汇总')
+      expect(result).toContain('作者:')
+    })
+
+    it('should use translated labels in markdown output (English)', () => {
+      const result = execSync(`node build/cli.js --dir ${testDir} --lang en --md`, {
+        encoding: 'utf8',
+        cwd: process.cwd(),
+      })
+
+      expect(result).toContain('Git Commit Summary')
+      expect(result).toContain('author:')
+    })
+  })
+
+  describe('Bash Implementation', () => {
+    it('should show Chinese help by default', () => {
+      // Skip on Windows
+      if (process.platform === 'win32') {
+        console.log('Skipping bash test on Windows')
+        return
+      }
+
+      const result = execSync('bash build/weekly-git-summary.sh --help', {
+        encoding: 'utf8',
+        cwd: process.cwd(),
+      })
+
+      expect(result).toContain('使用方法')
+      expect(result).toContain('选项')
+    })
+
+    it('should show English help with --lang en', () => {
+      // Skip on Windows
+      if (process.platform === 'win32') {
+        console.log('Skipping bash test on Windows')
+        return
+      }
+
+      const result = execSync('bash build/weekly-git-summary.sh --help --lang en', {
+        encoding: 'utf8',
+        cwd: process.cwd(),
+      })
+
+      expect(result).toContain('Usage:')
+      expect(result).toContain('Options:')
+    })
+
+    it('should use translated labels in text output (Chinese)', () => {
+      // Skip on Windows
+      if (process.platform === 'win32') {
+        console.log('Skipping bash test on Windows')
+        return
+      }
+
+      const result = execSync(`bash build/weekly-git-summary.sh --dir ${testDir} --lang zh 2>/dev/null`, {
+        encoding: 'utf8',
+        cwd: process.cwd(),
+      })
+
+      expect(result).toContain('项目:')
+      expect(result).toContain('作者:')
+    })
+
+    it('should use translated labels in text output (English)', () => {
+      // Skip on Windows
+      if (process.platform === 'win32') {
+        console.log('Skipping bash test on Windows')
+        return
+      }
+
+      const result = execSync(`bash build/weekly-git-summary.sh --dir ${testDir} --lang en 2>/dev/null`, {
+        encoding: 'utf8',
+        cwd: process.cwd(),
+      })
+
+      expect(result).toContain('Project:')
+      expect(result).toContain('author:')
+    })
+  })
+
+  describe('Cross-platform consistency', () => {
+    it('should produce consistent JSON output regardless of language', () => {
+      const resultZh = execSync(`node build/cli.js --dir ${testDir} --lang zh --json`, {
+        encoding: 'utf8',
+        cwd: process.cwd(),
+      })
+
+      const resultEn = execSync(`node build/cli.js --dir ${testDir} --lang en --json`, {
+        encoding: 'utf8',
+        cwd: process.cwd(),
+      })
+
+      const jsonZh = JSON.parse(resultZh)
+      const jsonEn = JSON.parse(resultEn)
+
+      // JSON structure should be identical
+      expect(jsonZh.repositories.length).toBe(jsonEn.repositories.length)
+      expect(jsonZh.timeRange.since).toBe(jsonEn.timeRange.since)
+      expect(jsonZh.timeRange.until).toBe(jsonEn.timeRange.until)
+    })
+
+    it('should handle invalid language code gracefully', () => {
+      // Bash script exits with error on invalid language, which is correct behavior
+      // TypeScript version should fallback to Chinese
+      try {
+        const result = execSync(`node build/weekly-git-summary.js --dir ${testDir} --lang invalid --json`, {
+          encoding: 'utf8',
+          cwd: process.cwd(),
+        })
+
+        // Should fallback to Chinese
+        const jsonResult = JSON.parse(result)
+        expect(jsonResult).toHaveProperty('repositories')
+      }
+      catch (error: any) {
+        // If it fails, it should be due to bash script rejecting invalid language
+        expect(error).toBeDefined()
+      }
+    })
+  })
+
+  describe('i18n with other features', () => {
+    it('should work with conventional commits and i18n', () => {
+      const result = execSync(`node build/cli.js --dir ${testDir} --lang en --conventional --json`, {
+        encoding: 'utf8',
+        cwd: process.cwd(),
+      })
+
+      const jsonResult = JSON.parse(result)
+      expect(jsonResult).toHaveProperty('repositories')
+      expect(jsonResult.conventional).toBe(true)
+    })
+
+    it('should work with time-range and i18n', () => {
+      const result = execSync(`node build/cli.js --dir ${testDir} --lang en --time-range today --json`, {
+        encoding: 'utf8',
+        cwd: process.cwd(),
+      })
+
+      const jsonResult = JSON.parse(result)
+      expect(jsonResult).toHaveProperty('repositories')
+      expect(jsonResult.timeRange.since).toBe(jsonResult.timeRange.until)
+    })
+
+    it('should work with author filter and i18n', () => {
+      const result = execSync(`node build/cli.js --dir ${testDir} --lang en --author "Test User" --json`, {
+        encoding: 'utf8',
+        cwd: process.cwd(),
+      })
+
+      const jsonResult = JSON.parse(result)
+      expect(jsonResult).toHaveProperty('repositories')
+      expect(jsonResult.author).toBe('Test User')
+    })
+  })
+})


### PR DESCRIPTION
## Summary
Complete i18n implementation for both CLI and HTML output, plus GNU date compatibility fix for Linux.

## Changes
1. **fix: support GNU date on Linux** (ad3205b)
   - BSD date (-v) fails on Linux with 'invalid argument' error
   - Auto-detect GNU vs BSD date and use appropriate flags

2. **feat(i18n): complete translation coverage for output labels** (46236e1)
   - CLI output labels now respect --lang flag
   - Previously only headers were translated, commit metadata remained Chinese

3. **feat(i18n): move html text to translation keys** (3ec55c9)
   - HTML template uses data-i18n attributes instead of hardcoded text
   - Single HTML file supports both zh/en via data-lang attribute
   - More maintainable than separate .html files per language

## Testing
- All i18n tests pass (tests/i18n.test.ts)
- CLI on Linux without "date: invalid option -- 'v'"
- HTML output respects --lang flag
